### PR TITLE
edit deprecated solve_triangular/cholesky for new pytorch version

### DIFF
--- a/methods/whitening.py
+++ b/methods/whitening.py
@@ -34,9 +34,12 @@ class Whitening2d(nn.Module):
 
         f_cov_shrinked = (1 - self.eps) * f_cov + self.eps * eye
 
-        inv_sqrt = torch.triangular_solve(
-            eye, torch.cholesky(f_cov_shrinked), upper=False
-        )[0]
+        inv_sqrt = torch.linalg.solve_triangular(
+            torch.linalg.cholesky(f_cov_shrinked),
+            eye, 
+            upper=False
+            )
+        
         inv_sqrt = inv_sqrt.contiguous().view(
             self.num_features, self.num_features, 1, 1
         )


### PR DESCRIPTION
Hello,

I just edit in whitening.py the torch.solve_triangular and torch.cholesky as they are deprecated in current PyTorch version.

For more information:

- https://pytorch.org/docs/stable/generated/torch.linalg.solve_triangular.html
- https://pytorch.org/docs/stable/generated/torch.cholesky.html

note: It's normal if argument are swapped in the torch.linagl.solve_triangular, here is the corresponding documentation : 
https://pytorch.org/docs/stable/generated/torch.linalg.solve_triangular.html

Have a nice day ! 

Lucas.